### PR TITLE
Test: @WebMvcTest, @AuthenticationPrincipal 관련한 테스트 이슈 해결 

### DIFF
--- a/src/test/java/com/example/shoppingmallproject/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/example/shoppingmallproject/cart/controller/CartControllerTest.java
@@ -2,6 +2,7 @@ package com.example.shoppingmallproject.cart.controller;
 
 import com.example.shoppingmallproject.cart.dto.CartsWithProductsDto;
 import com.example.shoppingmallproject.cart.service.CartService;
+import com.example.shoppingmallproject.common.security.jwt.JwtUtil;
 import com.example.shoppingmallproject.common.security.userDetails.entity.UserDetailsImpl;
 import com.example.shoppingmallproject.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +14,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -28,17 +32,21 @@ import static org.mockito.Mockito.*;
 public class CartControllerTest {
     @Autowired
     MockMvc mockMvc;
+    @MockBean
+    JwtUtil jwtUtil;
 
     @MockBean
     private CartService cartService;
-    @MockBean
+
     private UserDetailsImpl userDetails;
     private User user;
     @BeforeEach
     void setUp(){
         user = mock(User.class); // user 목 객체 생성
+        userDetails = mock(UserDetailsImpl.class);
         when(user.getId()).thenReturn(1L); // 유저의 아이디는 1로
         when(userDetails.getUser()).thenReturn(user);  // userDetailsImpl 에서 getUSER() 호출 시 위 유저 반환하도록 설정
+
     }
 
     // TODO: 2023/07/18 해당 부분은 userDetails 가져오는 부분이 완성되면, 다시 테스트 하겠습니다.
@@ -46,7 +54,7 @@ public class CartControllerTest {
     void getCartsWithProducts() throws Exception {
         Long userId = 1L;
         List<CartsWithProductsDto> expectedCartsWithProducts = new ArrayList<>();
-        when(userDetails.getUser()).thenReturn(user);
+//        when(userDetails.getUser()).thenReturn(user);
         when(cartService.getCartsWithProducts(userId)).thenReturn(expectedCartsWithProducts);
 
         // Act & Assert

--- a/src/test/java/com/example/shoppingmallproject/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/example/shoppingmallproject/cart/controller/CartControllerTest.java
@@ -46,7 +46,8 @@ public class CartControllerTest {
         userDetails = mock(UserDetailsImpl.class);
         when(user.getId()).thenReturn(1L); // 유저의 아이디는 1로
         when(userDetails.getUser()).thenReturn(user);  // userDetailsImpl 에서 getUSER() 호출 시 위 유저 반환하도록 설정
-
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, null));
     }
 
     // TODO: 2023/07/18 해당 부분은 userDetails 가져오는 부분이 완성되면, 다시 테스트 하겠습니다.


### PR DESCRIPTION
1. @WebMvcTest를 활용하여 Controller Test 진행시 JwtUtil이 Bean 등록되지 않으면서 SecurityConfig에 의존성 주입이 되지 않는 문제해결 
2. @AuthenticationPrincipal 활용하여 UserDetails 객체를 사용하는 로직을 테스트하기 위한 SecurityContext 세팅