### PR TITLE
Chore: 테스트 환경 분리를 위한 build.gradle & apllication.properties 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 
     //test for redis with docker-container
     testImplementation "org.testcontainers:testcontainers:1.17.6"
+
+    // test 환경용 h2
+    testImplementation "com.h2database:h2"
 }
 
 tasks.named('test') {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+#jwt
+jwt.secret.key = 7Jqw66as64qU66qo65GQ67aV6rS07ZWY64qU67OE7J2Y64K067aA7JeQ7ISc7ZWp7ISx65CQ64uk6re465+s66+A66Gc7Jqw66as64qU67OE7J2Y7J6Q64WA64uk
+jwt.live.atk = 36000
+jwt.live.rtk = 62000
+
+#redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+server.port=8080
+


### PR DESCRIPTION
테스트 진행시 배포용 DB를 사용하는 것을 막고자 build.gradle에 H2DB 의존성을 추가하고, 
test/resources/application.properties에서 MariaDB 관련 설정을 제거하여 defaultDB로 H2DB를 사용하도록 하였습니다.