### PR TITLE
Feat : Redis를 이용해서 로그인 시 "여러 브라우저" 에서도 문제 없이 동작하게 변경.

### DIFF
--- a/src/main/java/com/example/shoppingmallproject/common/redis/RedisAuthDAO.java
+++ b/src/main/java/com/example/shoppingmallproject/common/redis/RedisAuthDAO.java
@@ -1,0 +1,85 @@
+package com.example.shoppingmallproject.common.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisAuthDAO {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     *
+     * @param userEmail 레디스 키
+     * @param browser 해쉬 키
+     * @param refreshToken 해쉬 키의 대응되는 밸류
+     * @param expiration 만료 시간 (Duration.ofMills 로 스태틱하게 사용합니다)
+     */
+    public void storeRefreshToken(String userEmail, String browser, String refreshToken, Duration expiration) {
+        List<Object> refreshTokenData = new ArrayList<>(3);
+        refreshTokenData.add(browser);
+        refreshTokenData.add(refreshToken);
+        refreshTokenData.add(expiration.toMillis());
+        try {
+            String refreshTokenDataString = objectMapper.writeValueAsString(refreshTokenData);
+            // List<Object> 형태를 String으로 형변환 (Serializer)
+            hashOperations.put(userEmail, browser, refreshTokenDataString);
+            // userEmail 은 Redis 의 키, browser 는 해쉬키(키 안의 키), 위에서 직렬화한 데이터 = 밸류
+            // 따라서 레디스에서 -> HashOperations.get(userEmail, HashKey(==browser)) 하면 저 안의 밸류 가져올 수 있음.
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     *
+     * @param userEmail 키로 쓰일 유저이메일
+     * @param browser 해쉬키로 쓰일 브라우저 이름(크롬, 사파리, 파이어폭스 ..)
+     * @param currentTime 체크하는 시점의 시간. 아규먼트로 "호출" 하실때는 System.currentTimeMillis() 로 호출하시면 됩니다.
+     * @return 리프레쉬토큰이 null 이 아니며, currentTime 이 만료 시간인 Duration 보다 크다면 (시간이 지났다면) true 반환합니다.
+     */
+    public boolean isRefreshTokenExpired(String userEmail, String browser, long currentTime) {
+        List<Object> refreshTokenData = getRefreshTokenData(userEmail, browser);
+        return refreshTokenData != null && currentTime >= (long) refreshTokenData.get(2);
+    }
+
+    /**
+     *
+     * @param userEmail 키
+     * @param browser 해쉬 키
+     * @return 유저의 키 안에 있는 해쉬 키의 데이터를 반환합니다. 해쉬 키의 상응 데이터는 List<> 타입입니다.
+     */
+    public List<Object> getRefreshTokenData(String userEmail, String browser) {
+        String refreshTokenDataString = hashOperations.get(userEmail, browser);
+        if (refreshTokenDataString != null) {
+            try {
+                return objectMapper.readValue(refreshTokenDataString, List.class);
+                // objectMapper 로
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 
+     * @param userEmail 레디스 키
+     * @param browser 해쉬 키
+     *                해쉬 키를 삭제합니다.
+     */
+    public void removeRefreshToken(String userEmail, String browser) {
+        hashOperations.delete(userEmail, browser);
+    }
+}

--- a/src/main/java/com/example/shoppingmallproject/common/redis/RedisAuthDAO.java
+++ b/src/main/java/com/example/shoppingmallproject/common/redis/RedisAuthDAO.java
@@ -2,7 +2,7 @@ package com.example.shoppingmallproject.common.redis;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -12,12 +12,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Repository
-@RequiredArgsConstructor
 public class RedisAuthDAO {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+    private final HashOperations<String, String, String> hashOperations;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public RedisAuthDAO(@Qualifier("redisTemplate") RedisTemplate<String, String> redisTemplate1, RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate1;
+        this.hashOperations = redisTemplate.opsForHash();
+    }
 
     /**
      *

--- a/src/main/java/com/example/shoppingmallproject/common/redis/RedisAuthDAO.java
+++ b/src/main/java/com/example/shoppingmallproject/common/redis/RedisAuthDAO.java
@@ -14,12 +14,10 @@ import java.util.List;
 @Repository
 public class RedisAuthDAO {
 
-    private final RedisTemplate<String, String> redisTemplate;
     private final HashOperations<String, String, String> hashOperations;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public RedisAuthDAO(@Qualifier("redisTemplate") RedisTemplate<String, String> redisTemplate1, RedisTemplate<String, String> redisTemplate) {
-        this.redisTemplate = redisTemplate1;
+    public RedisAuthDAO(RedisTemplate<String, String> redisTemplate, HashOperations<String, String, String> hashOperations) {
         this.hashOperations = redisTemplate.opsForHash();
     }
 

--- a/src/main/java/com/example/shoppingmallproject/common/redis/RedisConfig.java
+++ b/src/main/java/com/example/shoppingmallproject/common/redis/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -36,6 +37,11 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Bean
+    public HashOperations<String, String, String> hashOperations(RedisTemplate<String, String> redisTemplate) {
+        return redisTemplate.opsForHash();
     }
 
     @Bean

--- a/src/test/java/com/example/shoppingmallproject/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/example/shoppingmallproject/cart/controller/CartControllerTest.java
@@ -10,16 +10,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -31,7 +28,6 @@ import java.util.NoSuchElementException;
 import static org.mockito.Mockito.*;
 
 @WebMvcTest(CartController.class)
-@MockBean(JpaMetamodelMappingContext.class)
 public class CartControllerTest {
     @Autowired
     MockMvc mockMvc;


### PR DESCRIPTION
# [블로그 링크](https://velog.io/@calaf/Redis%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%A6%AC%ED%94%84%EB%A0%88%EC%89%AC-%ED%86%A0%ED%81%B0-%EA%B4%80%EB%A6%AC-%EC%95%84%EC%9D%B4%EB%94%94%EC%96%B4)

여러 브라우저, 혹은 여러 기기에서 동시 로그인 시에 먼저 접속한 계정에서 접속 불가 이슈를 예상했습니다. 예를 들어

## 1번 시나리오

크롬에서 로그인 -> 사파리에서 로그인(이 시점에서 레디스 안에 있는 리프레쉬 토큰은 "사파리" 기준으로 바뀌어버림::로그인 시 리프레쉬 토큰을 새로 발급하므로)

## 2번 시나리오

로그인 시 레디스에 있는 토큰을 "체크" 해서 발급 해준다고 하더라도, 재발급 시 문제가 될 수 있음

크롬 로그인 -> 사파리 로그인 -> 크롬 만료, 레디스에 있는 리프레쉬 토큰 키 값 바꿈 -> 사파리 측에서는 유효기간이 남아있는 "유효한 리프레쉬 토큰"을 가지고 있지만, 레디스에 있는 리프레쉬 토큰과 __다름__. 따라서 다시 로그인해야하고 -> 그러면 크롬에서 다시 막힘

### 그러므로

브라우저별로 리프레쉬 토큰을 저장 가능하도록 변경했습니다.